### PR TITLE
v0.10.0

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -119,7 +119,6 @@ opt_in_rules:
   - unused_enumerated
   - unused_import
   - unused_optional_binding
-  - unused_private_declaration
   - vertical_parameter_alignment
   - vertical_whitespace
   - void_return
@@ -136,7 +135,7 @@ warning_threshold: 15
 file_header:
   required_pattern: |
                     \/\/
-                    \/\/ Copyright \(C\) 2015-2019 Virgil Security Inc.
+                    \/\/ Copyright \(C\) 2015-2021 Virgil Security Inc.
                     \/\/
                     \/\/ All rights reserved.
                     \/\/

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ script:
     fi
 
   - carthage version
-  - carthage bootstrap --platform ${CARTHAGE_PLATFORM_NAME}
+  - carthage bootstrap --use-xcframeworks --platform ${CARTHAGE_PLATFORM_NAME}
 
   - |
     if [ $SWIFT_LINT == "YES" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ deploy:
   # Upload framework to gh-releases for carthage
   - provider: releases
     api_key: $GITHUB_ACCESS_TOKEN
-    file: "$FRAMEWORK_NAME.framework.zip"
+    file: "$FRAMEWORK_NAME.xcframework.zip"
     skip_cleanup: true
     on:
       repo: $REPO

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,23 @@
 language: objective-c
-osx_image: xcode11.4
+osx_image: xcode12.5
 
 env:
   global:
     - LC_CTYPE=en_US.UTF-8
     - PROJECT=VirgilSDKPythia.xcodeproj
-    - IOS_SDK=iphonesimulator13.4
-    - MACOS_SDK=macosx10.15
-    - TVOS_SDK=appletvsimulator13.4
-    - WATCHOS_SDK=watchsimulator6.2
+    - IOS_SDK=iphonesimulator14.5
+    - MACOS_SDK=macosx11.3
+    - TVOS_SDK=appletvsimulator14.5
+    - WATCHOS_SDK=watchsimulator7.4
     - FRAMEWORK_NAME=VirgilSDKPythia
     - REPO=VirgilSecurity/virgil-pythia-x
 
   matrix:
     - DESTINATION=""                                           PREFIX=""         SDK=""              BUILD="0"  PUBLISH_CARTHAGE="YES"  CARTHAGE_PLATFORM_NAME="Mac"      PUBLISH_POD="YES"  PUBLISH_DOCS="YES"  SWIFT_LINT="YES"
-    - DESTINATION="OS=13.4.1,name=iPhone 8"                      PREFIX="iOS"      SDK="$IOS_SDK"      BUILD="2"  PUBLISH_CARTHAGE="NO"   CARTHAGE_PLATFORM_NAME="iOS"      PUBLISH_POD="NO"   PUBLISH_DOCS="NO"   SWIFT_LINT="NO"
+    - DESTINATION="OS=14.5,name=iPhone 8"                      PREFIX="iOS"      SDK="$IOS_SDK"      BUILD="2"  PUBLISH_CARTHAGE="NO"   CARTHAGE_PLATFORM_NAME="iOS"      PUBLISH_POD="NO"   PUBLISH_DOCS="NO"   SWIFT_LINT="NO"
     - DESTINATION="arch=x86_64"                                PREFIX="macOS"    SDK="$MACOS_SDK"    BUILD="2"  PUBLISH_CARTHAGE="NO"   CARTHAGE_PLATFORM_NAME="Mac"      PUBLISH_POD="NO"   PUBLISH_DOCS="NO"   SWIFT_LINT="NO"
-    - DESTINATION="OS=13.4,name=Apple TV 4K"                   PREFIX="tvOS"     SDK="$TVOS_SDK"     BUILD="2"  PUBLISH_CARTHAGE="NO"   CARTHAGE_PLATFORM_NAME="tvOS"     PUBLISH_POD="NO"   PUBLISH_DOCS="NO"   SWIFT_LINT="NO"
-    - DESTINATION="OS=6.2,name=Apple Watch Series 4 - 44mm"    PREFIX="watchOS"  SDK="$WATCHOS_SDK"  BUILD="1"  PUBLISH_CARTHAGE="NO"   CARTHAGE_PLATFORM_NAME="watchOS"  PUBLISH_POD="NO"   PUBLISH_DOCS="NO"   SWIFT_LINT="NO"
+    - DESTINATION="OS=14.5,name=Apple TV"                      PREFIX="tvOS"     SDK="$TVOS_SDK"     BUILD="2"  PUBLISH_CARTHAGE="NO"   CARTHAGE_PLATFORM_NAME="tvOS"     PUBLISH_POD="NO"   PUBLISH_DOCS="NO"   SWIFT_LINT="NO"
+    - DESTINATION="OS=7.4,name=Apple Watch Series 6 - 40mm"    PREFIX="watchOS"  SDK="$WATCHOS_SDK"  BUILD="1"  PUBLISH_CARTHAGE="NO"   CARTHAGE_PLATFORM_NAME="watchOS"  PUBLISH_POD="NO"   PUBLISH_DOCS="NO"   SWIFT_LINT="NO"
 
 before_install:
   - set -e
@@ -57,11 +57,8 @@ script:
     fi
 
   # Build with carthage
-  - if [ $PUBLISH_CARTHAGE == "YES" ]; then
-      brew update;
-      brew outdated carthage || brew upgrade carthage;
-      carthage build --no-skip-current;
-      carthage archive;
+  - if [[ $PUBLISH_CARTHAGE == "YES" && $TRAVIS_TAG =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+        ./CI/publish-carthage.sh;
     fi
   
   - if [[ $PUBLISH_DOCS = "YES" && $TRAVIS_TAG =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then

--- a/CI/publish-carthage.sh
+++ b/CI/publish-carthage.sh
@@ -1,0 +1,8 @@
+brew update;
+brew outdated carthage || brew upgrade carthage;
+carthage build --use-xcframeworks --no-skip-current;
+
+# TODO: Should be replaced by carthage archive, when it supports xcframeworks
+FRAMEWORKS_PATH=Carthage/Build
+find ${FRAMEWORKS_PATH} ! -name 'VirgilSDKPythia.xcframework' -delete
+zip -r VirgilSDKPythia.xcframework.zip ${FRAMEWORKS_PATH}

--- a/CI/publish-carthage.sh
+++ b/CI/publish-carthage.sh
@@ -3,6 +3,4 @@ brew outdated carthage || brew upgrade carthage;
 carthage build --use-xcframeworks --no-skip-current;
 
 # TODO: Should be replaced by carthage archive, when it supports xcframeworks
-FRAMEWORKS_PATH=Carthage/Build
-find ${FRAMEWORKS_PATH} -mindepth 1 -maxdepth 1 ! -name 'VirgilSDKPythia.xcframework' -exec rm -rvf {} \;
-zip -r VirgilSDKPythia.xcframework.zip ${FRAMEWORKS_PATH}
+zip -r VirgilSDKPythia.xcframework.zip Carthage/Build/VirgilSDKPythia.xcframework

--- a/CI/publish-carthage.sh
+++ b/CI/publish-carthage.sh
@@ -4,5 +4,5 @@ carthage build --use-xcframeworks --no-skip-current;
 
 # TODO: Should be replaced by carthage archive, when it supports xcframeworks
 FRAMEWORKS_PATH=Carthage/Build
-find ${FRAMEWORKS_PATH} ! -name 'VirgilSDKPythia.xcframework' -delete
+find ${FRAMEWORKS_PATH} -mindepth 1 -maxdepth 1 ! -name 'VirgilSDKPythia.xcframework' -exec rm -rvf {} \;
 zip -r VirgilSDKPythia.xcframework.zip ${FRAMEWORKS_PATH}

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "VirgilSecurity/virgil-sdk-x" "develop"
-github "VirgilSecurity/virgil-cryptowrapper-x" "0.16.0-rc2"
+github "VirgilSecurity/virgil-sdk-x" ~> 8.0.0
+github "VirgilSecurity/virgil-cryptowrapper-x" ~> 0.16.0

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "VirgilSecurity/virgil-sdk-x" ~> 7.2.1
-github "VirgilSecurity/virgil-cryptowrapper-x" ~> 0.15.2
+github "VirgilSecurity/virgil-sdk-x" "develop"
+github "VirgilSecurity/virgil-cryptowrapper-x" "0.16.0-rc2"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "VirgilSecurity/virgil-crypto-c" "v0.15.2"
-github "VirgilSecurity/virgil-crypto-x" "5.5.0"
-github "VirgilSecurity/virgil-cryptowrapper-x" "0.15.2"
-github "VirgilSecurity/virgil-sdk-x" "7.2.1"
+github "VirgilSecurity/virgil-crypto-c" "v0.16.0-rc1"
+github "VirgilSecurity/virgil-crypto-x" "3df3a53e5ff6205c99a67c90a8b86a5820241c64"
+github "VirgilSecurity/virgil-cryptowrapper-x" "0.16.0-rc2"
+github "VirgilSecurity/virgil-sdk-x" "99684e8a77a20d93e7af24d931695d25153cd92e"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "VirgilSecurity/virgil-crypto-c" "v0.16.0-rc1"
-github "VirgilSecurity/virgil-crypto-x" "3df3a53e5ff6205c99a67c90a8b86a5820241c64"
-github "VirgilSecurity/virgil-cryptowrapper-x" "0.16.0-rc2"
-github "VirgilSecurity/virgil-sdk-x" "99684e8a77a20d93e7af24d931695d25153cd92e"
+github "VirgilSecurity/virgil-crypto-c" "v0.16.0"
+github "VirgilSecurity/virgil-crypto-x" "6.0.0"
+github "VirgilSecurity/virgil-cryptowrapper-x" "0.16.0"
+github "VirgilSecurity/virgil-sdk-x" "8.0.0"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The BSD 3-Clause License (BSD)
 
-Copyright (c) 2015-2019, Virgil Security, Inc.
+Copyright (c) 2015-2021, Virgil Security, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ github "VirgilSecurity/virgil-pythia-x" ~> 0.9.1
 To link prebuilt frameworks to your app, run following command:
 
 ```bash
-$ carthage update
+$ carthage update --use-xcframeworks
 ```
 
 This will build each dependency or download a pre-compiled framework from github Releases.
@@ -93,25 +93,7 @@ On your application targets’ “General” settings tab, in the “Linked Fram
  - VSCFoundation
  - VSCPythia
 
-On your application targets’ “Build Phases” settings tab, click the “+” icon and choose “New Run Script Phase.” Create a Run Script in which you specify your shell (ex: */bin/sh*), add the following contents to the script area below the shell:
-
-```bash
-/usr/local/bin/carthage copy-frameworks
-```
-
-and add the paths to the frameworks you want to use under “Input Files”, e.g.:
-
-```
-$(SRCROOT)/Carthage/Build/iOS/VirgilSDKPythia.framework
-$(SRCROOT)/Carthage/Build/iOS/VirgilSDK.framework
-$(SRCROOT)/Carthage/Build/iOS/VirgilCryptoAPI.framework
-$(SRCROOT)/Carthage/Build/iOS/VirgilCrypto.framework
-$(SRCROOT)/Carthage/Build/iOS/VirgilCryptoFoundation.framework
-$(SRCROOT)/Carthage/Build/iOS/VirgilCryptoPythia.framework
-$(SRCROOT)/Carthage/Build/iOS/VSCCommon.framework
-$(SRCROOT)/Carthage/Build/iOS/VSCFoundation.framework
-$(SRCROOT)/Carthage/Build/iOS/VSCPythia.framework
-```
+Check Embed & sign for each.
 
 ##### Building for macOS
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To integrate Virgil Pythia into your Xcode project using CocoaPods, specify it i
 target '<Your Target Name>' do
   use_frameworks!
 
-  pod 'VirgilSDKPythia', '~> 0.9.1'
+  pod 'VirgilSDKPythia', '~> 0.10.0'
 end
 ```
 
@@ -67,7 +67,7 @@ $ brew install carthage
 To integrate Virgil Pythia into your Xcode project using Carthage, create an empty file with name *Cartfile* in your project's root folder and add following lines to your *Cartfile*
 
 ```
-github "VirgilSecurity/virgil-pythia-x" ~> 0.9.1
+github "VirgilSecurity/virgil-pythia-x" ~> 0.10.0
 ```
 
 #### Linking against prebuilt binaries

--- a/Source/BrainKey/BrainKey+Obj-C.swift
+++ b/Source/BrainKey/BrainKey+Obj-C.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2015-2019 Virgil Security Inc.
+// Copyright (C) 2015-2021 Virgil Security Inc.
 //
 // All rights reserved.
 //

--- a/Source/BrainKey/BrainKey.swift
+++ b/Source/BrainKey/BrainKey.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2015-2019 Virgil Security Inc.
+// Copyright (C) 2015-2021 Virgil Security Inc.
 //
 // All rights reserved.
 //
@@ -59,7 +59,7 @@ import VirgilCrypto
     ///   - brainKeyId: optional brainKey identifier (in case one wants to generate several key pairs from 1 password)
     /// - Returns: GenericOperation with VirgilKeyPair
     open func generateKeyPair(password: String, brainKeyId: String? = nil) -> GenericOperation<VirgilKeyPair> {
-        return CallbackOperation { _, completion in
+        CallbackOperation { _, completion in
             do {
                 let blindedResult = try self.pythiaCrypto.blind(password: password)
 

--- a/Source/BrainKey/BrainKeyContext.swift
+++ b/Source/BrainKey/BrainKeyContext.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2015-2019 Virgil Security Inc.
+// Copyright (C) 2015-2021 Virgil Security Inc.
 //
 // All rights reserved.
 //
@@ -69,7 +69,7 @@ import VirgilCrypto
     /// - Parameter accessTokenProvider: AccessTokenProvider implementation
     /// - Returns: Initialized BrainKeyContext instance
     @objc public static func makeContext(accessTokenProvider: AccessTokenProvider) throws -> BrainKeyContext {
-        return try BrainKeyContext(client: PythiaClient(accessTokenProvider: accessTokenProvider),
-                                   pythiaCrypto: PythiaCrypto(crypto: try VirgilCrypto()))
+        try BrainKeyContext(client: PythiaClient(accessTokenProvider: accessTokenProvider),
+                            pythiaCrypto: PythiaCrypto(crypto: try VirgilCrypto()))
     }
 }

--- a/Source/Client/PythiaClient+Queries.swift
+++ b/Source/Client/PythiaClient+Queries.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2015-2019 Virgil Security Inc.
+// Copyright (C) 2015-2021 Virgil Security Inc.
 //
 // All rights reserved.
 //
@@ -39,7 +39,7 @@ import VirgilSDK
 // MARK: - PythiaClientProtocol implementation
 extension PythiaClient: PythiaClientProtocol {
     private func createRetry() -> RetryProtocol {
-        return ExpBackoffRetry(config: self.retryConfig)
+        ExpBackoffRetry(config: self.retryConfig)
     }
 
     /// Generates seed using given blinded password and brainkey id

--- a/Source/Client/PythiaClient.swift
+++ b/Source/Client/PythiaClient.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2015-2019 Virgil Security Inc.
+// Copyright (C) 2015-2021 Virgil Security Inc.
 //
 // All rights reserved.
 //
@@ -67,11 +67,11 @@ import VirgilSDK
     }
 
     /// Error domain or Error instances thrown from Service
-    @objc public static var errorDomain: String { return PythiaClient.serviceErrorDomain }
+    @objc public static var errorDomain: String { PythiaClient.serviceErrorDomain }
     /// Code of error
-    @objc public var errorCode: Int { return self.rawServiceError.code }
+    @objc public var errorCode: Int { self.rawServiceError.code }
     /// Provides info about the error. Error message can be recieve by NSLocalizedDescriptionKey
-    @objc public var errorUserInfo: [String: Any] { return [NSLocalizedDescriptionKey: self.rawServiceError.message] }
+    @objc public var errorUserInfo: [String: Any] { [NSLocalizedDescriptionKey: self.rawServiceError.message] }
 }
 
 /// Class representing operations with Virgil Cards service
@@ -81,7 +81,7 @@ import VirgilSDK
     @objc public static let defaultURL = URL(string: "https://api.virgilsecurity.com")!
     // swiftlint:enable force_unwrapping
     /// Error domain for Error instances thrown from service
-    @objc override open class var serviceErrorDomain: String { return "VirgilSDK.PythiaServiceErrorDomain" }
+    @objc override open class var serviceErrorDomain: String { "VirgilSDK.PythiaServiceErrorDomain" }
 
     internal let retryConfig: ExpBackoffRetry.Config
 

--- a/Source/Client/PythiaClientProtocol.swift
+++ b/Source/Client/PythiaClientProtocol.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2015-2019 Virgil Security Inc.
+// Copyright (C) 2015-2021 Virgil Security Inc.
 //
 // All rights reserved.
 //

--- a/Source/Client/PythiaClientProtocol.swift
+++ b/Source/Client/PythiaClientProtocol.swift
@@ -39,7 +39,7 @@ import Foundation
 /// Protocol for PythiaClient
 ///
 /// See: PythiaClient for default implementation
-@objc(VSYPythiaClientProtocol) public protocol PythiaClientProtocol: class {
+@objc(VSYPythiaClientProtocol) public protocol PythiaClientProtocol: AnyObject {
     /// Generates seed using given blinded password and brainkey id
     ///
     /// - Parameters:

--- a/Source/Crypto/BlindResult.swift
+++ b/Source/Crypto/BlindResult.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2015-2019 Virgil Security Inc.
+// Copyright (C) 2015-2021 Virgil Security Inc.
 //
 // All rights reserved.
 //

--- a/Source/Crypto/PythiaCrypto.swift
+++ b/Source/Crypto/PythiaCrypto.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2015-2019 Virgil Security Inc.
+// Copyright (C) 2015-2021 Virgil Security Inc.
 //
 // All rights reserved.
 //
@@ -116,7 +116,7 @@ import VirgilCryptoPythia
     /// - Returns: GT deblinded transformed password
     /// - Throws: Rethrows from VirgilPythia.deblind
     @objc open func deblind(transformedPassword: Data, blindingSecret: Data) throws -> Data {
-        return try Pythia.deblind(transformedPassword: transformedPassword, blindingSecret: blindingSecret)
+        try Pythia.deblind(transformedPassword: transformedPassword, blindingSecret: blindingSecret)
     }
 
     /// Generates key pair of given type using random seed
@@ -129,6 +129,6 @@ import VirgilCryptoPythia
     ///   - `PythiaCryptoError.errorWhileGeneratingKeyPair` if key generation failed
     ///   - Rethrows from VirgilCrypto.generateKeyPair
     @objc open func generateKeyPair(usingSeed seed: Data) throws -> VirgilKeyPair {
-        return try self.crypto.generateKeyPair(usingSeed: seed)
+        try self.crypto.generateKeyPair(usingSeed: seed)
     }
 }

--- a/Source/Crypto/PythiaCryptoProtocol.swift
+++ b/Source/Crypto/PythiaCryptoProtocol.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2015-2019 Virgil Security Inc.
+// Copyright (C) 2015-2021 Virgil Security Inc.
 //
 // All rights reserved.
 //

--- a/Source/Crypto/PythiaCryptoProtocol.swift
+++ b/Source/Crypto/PythiaCryptoProtocol.swift
@@ -38,7 +38,7 @@ import Foundation
 import VirgilCrypto
 
 /// Crypto operations needed for Pythia BrainKey
-@objc(VSYPythiaCryptoProtocol) public protocol PythiaCryptoProtocol: class {
+@objc(VSYPythiaCryptoProtocol) public protocol PythiaCryptoProtocol: AnyObject {
     /// Blinds password.
     ///
     /// Turns password into a pseudo-random string.

--- a/Tests/TestConfig.swift
+++ b/Tests/TestConfig.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2015-2019 Virgil Security Inc.
+// Copyright (C) 2015-2021 Virgil Security Inc.
 //
 // All rights reserved.
 //

--- a/Tests/VSY001_BrainKeyTests.swift
+++ b/Tests/VSY001_BrainKeyTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2015-2019 Virgil Security Inc.
+// Copyright (C) 2015-2021 Virgil Security Inc.
 //
 // All rights reserved.
 //

--- a/VirgilSDKPythia.podspec
+++ b/VirgilSDKPythia.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                        = "VirgilSDKPythia"
-  s.version                     = "0.9.1"
+  s.version                     = "0.10.0"
   s.swift_version               = "5.0"
   s.license                     = { :type => "BSD", :file => "LICENSE" }
   s.summary                     = "Virgil Pythia SDK for Apple devices and languages."
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target      = "9.0"
   s.watchos.deployment_target   = "2.0"
   s.source_files                = 'Source/**/*.{swift}'
-  s.dependency "VirgilSDK", "~> 7.2.1"
-  s.dependency "VirgilCryptoPythia", "~> 0.15.2"
+  s.dependency "VirgilSDK", "~> 8.0.0"
+  s.dependency "VirgilCryptoPythia", "~> 0.16.0"
 end

--- a/VirgilSDKPythia.xcodeproj/project.pbxproj
+++ b/VirgilSDKPythia.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 48;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -28,55 +28,6 @@
 		420120F7207625F500632FD9 /* PythiaClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 420120F1207625F400632FD9 /* PythiaClient.swift */; };
 		420120FA207625F500632FD9 /* PythiaClient+Queries.swift in Sources */ = {isa = PBXBuildFile; fileRef = 420120F5207625F400632FD9 /* PythiaClient+Queries.swift */; };
 		4201210B2077C1E800632FD9 /* PythiaCryptoProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4201210A2077C1E800632FD9 /* PythiaCryptoProtocol.swift */; };
-		423F7187223F981A00E8CDA9 /* VSCPythia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 423F7182223F981A00E8CDA9 /* VSCPythia.framework */; };
-		423F7188223F981A00E8CDA9 /* VSCCommon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 423F7183223F981A00E8CDA9 /* VSCCommon.framework */; };
-		423F7189223F981A00E8CDA9 /* VirgilCryptoFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 423F7184223F981A00E8CDA9 /* VirgilCryptoFoundation.framework */; };
-		423F718A223F981A00E8CDA9 /* VirgilCryptoPythia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 423F7185223F981A00E8CDA9 /* VirgilCryptoPythia.framework */; };
-		423F718B223F981A00E8CDA9 /* VSCFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 423F7186223F981A00E8CDA9 /* VSCFoundation.framework */; };
-		423F7191223F982B00E8CDA9 /* VSCPythia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 423F718C223F982A00E8CDA9 /* VSCPythia.framework */; };
-		423F7192223F982B00E8CDA9 /* VSCFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 423F718D223F982A00E8CDA9 /* VSCFoundation.framework */; };
-		423F7193223F982B00E8CDA9 /* VSCCommon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 423F718E223F982A00E8CDA9 /* VSCCommon.framework */; };
-		423F7194223F982B00E8CDA9 /* VirgilCryptoPythia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 423F718F223F982A00E8CDA9 /* VirgilCryptoPythia.framework */; };
-		423F7195223F982B00E8CDA9 /* VirgilCryptoFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 423F7190223F982B00E8CDA9 /* VirgilCryptoFoundation.framework */; };
-		423F719C223F983C00E8CDA9 /* VirgilCryptoFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 423F7196223F983B00E8CDA9 /* VirgilCryptoFoundation.framework */; };
-		423F719D223F983C00E8CDA9 /* VSCPythia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 423F7197223F983B00E8CDA9 /* VSCPythia.framework */; };
-		423F719F223F983C00E8CDA9 /* VSCFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 423F7199223F983C00E8CDA9 /* VSCFoundation.framework */; };
-		423F71A0223F983C00E8CDA9 /* VSCCommon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 423F719A223F983C00E8CDA9 /* VSCCommon.framework */; };
-		423F71A1223F983C00E8CDA9 /* VirgilCryptoPythia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 423F719B223F983C00E8CDA9 /* VirgilCryptoPythia.framework */; };
-		423F71A7223F985000E8CDA9 /* VSCCommon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 423F71A2223F985000E8CDA9 /* VSCCommon.framework */; };
-		423F71A8223F985000E8CDA9 /* VSCPythia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 423F71A3223F985000E8CDA9 /* VSCPythia.framework */; };
-		423F71A9223F985000E8CDA9 /* VirgilCryptoPythia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 423F71A4223F985000E8CDA9 /* VirgilCryptoPythia.framework */; };
-		423F71AA223F985000E8CDA9 /* VirgilCryptoFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 423F71A5223F985000E8CDA9 /* VirgilCryptoFoundation.framework */; };
-		423F71AB223F985000E8CDA9 /* VSCFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 423F71A6223F985000E8CDA9 /* VSCFoundation.framework */; };
-		423F71AC223F98CB00E8CDA9 /* VirgilCryptoFoundation.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 423F7184223F981A00E8CDA9 /* VirgilCryptoFoundation.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		423F71AF223F98CB00E8CDA9 /* VirgilCryptoPythia.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 423F7185223F981A00E8CDA9 /* VirgilCryptoPythia.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		423F71B2223F98CB00E8CDA9 /* VSCCommon.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 423F7183223F981A00E8CDA9 /* VSCCommon.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		423F71B5223F98CB00E8CDA9 /* VSCFoundation.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 423F7186223F981A00E8CDA9 /* VSCFoundation.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		423F71BD223F98CB00E8CDA9 /* VSCPythia.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 423F7182223F981A00E8CDA9 /* VSCPythia.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		4249A09B21EEA03E0076851C /* VirgilSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4249A09621EEA03D0076851C /* VirgilSDK.framework */; };
-		4249A09D21EEA03E0076851C /* VirgilCrypto.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4249A09821EEA03E0076851C /* VirgilCrypto.framework */; };
-		4249A0A821EEA04E0076851C /* VirgilSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4249A0A321EEA04E0076851C /* VirgilSDK.framework */; };
-		4249A0A921EEA04E0076851C /* VirgilCrypto.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4249A0A421EEA04E0076851C /* VirgilCrypto.framework */; };
-		4249A0B021EEA05C0076851C /* VirgilCrypto.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4249A0AB21EEA05C0076851C /* VirgilCrypto.framework */; };
-		4249A0B221EEA05C0076851C /* VirgilSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4249A0AD21EEA05C0076851C /* VirgilSDK.framework */; };
-		4249A0B921EEA0700076851C /* VirgilSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4249A0B421EEA0700076851C /* VirgilSDK.framework */; };
-		4249A0BA21EEA0700076851C /* VirgilCrypto.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4249A0B521EEA0700076851C /* VirgilCrypto.framework */; };
-		424F67BC21EEA40200E70BAB /* VirgilCrypto.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4249A0A421EEA04E0076851C /* VirgilCrypto.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		424F67BF21EEA40200E70BAB /* VirgilSDK.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4249A0A321EEA04E0076851C /* VirgilSDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		424F67C221EEA40E00E70BAB /* VirgilCrypto.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4249A09821EEA03E0076851C /* VirgilCrypto.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		424F67C521EEA40E00E70BAB /* VirgilSDK.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4249A09621EEA03D0076851C /* VirgilSDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		4264B5F92240C78C0096E6E4 /* VirgilCryptoFoundation.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 423F71A5223F985000E8CDA9 /* VirgilCryptoFoundation.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		4264B5FC2240C78C0096E6E4 /* VirgilCryptoPythia.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 423F71A4223F985000E8CDA9 /* VirgilCryptoPythia.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		4264B6032240C78C0096E6E4 /* VSCCommon.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 423F71A2223F985000E8CDA9 /* VSCCommon.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		4264B6042240C78C0096E6E4 /* VSCFoundation.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 423F71A6223F985000E8CDA9 /* VSCFoundation.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		4264B6052240C78C0096E6E4 /* VSCPythia.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 423F71A3223F985000E8CDA9 /* VSCPythia.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		4264B6382240C8BE0096E6E4 /* VirgilCryptoFoundation.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 423F7190223F982B00E8CDA9 /* VirgilCryptoFoundation.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		4264B63B2240C8BE0096E6E4 /* VirgilCryptoPythia.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 423F718F223F982A00E8CDA9 /* VirgilCryptoPythia.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		4264B63E2240C8BE0096E6E4 /* VSCCommon.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 423F718E223F982A00E8CDA9 /* VSCCommon.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		4264B6412240C8BE0096E6E4 /* VSCFoundation.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 423F718D223F982A00E8CDA9 /* VSCFoundation.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		4264B6492240C8BE0096E6E4 /* VSCPythia.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 423F718C223F982A00E8CDA9 /* VSCPythia.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		4264B64F2240C8BE0096E6E4 /* VirgilCrypto.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4249A0AB21EEA05C0076851C /* VirgilCrypto.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		4264B6512240C8BE0096E6E4 /* VirgilSDK.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4249A0AD21EEA05C0076851C /* VirgilSDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		42792EB820A9A4B400C95A29 /* BrainKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42792EB720A9A4B400C95A29 /* BrainKey.swift */; };
 		42792EBA20A9A52C00C95A29 /* BrainKey+Obj-C.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42792EB920A9A52C00C95A29 /* BrainKey+Obj-C.swift */; };
 		42792EBC20A9AAE200C95A29 /* BrainKeyContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42792EBB20A9AAE200C95A29 /* BrainKeyContext.swift */; };
@@ -121,6 +72,55 @@
 		42A76D4720AF1B4F00561EA2 /* TestConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42A76D4520AF1B4F00561EA2 /* TestConfig.swift */; };
 		42A76D4820AF1B4F00561EA2 /* TestConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42A76D4520AF1B4F00561EA2 /* TestConfig.swift */; };
 		42DD2A3C207522DA00C9C014 /* VirgilSDKPythia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 42DD298F20751B1A00C9C014 /* VirgilSDKPythia.framework */; };
+		9794E1C926AA0962001CF665 /* VSCFoundation.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9794E1C226AA0962001CF665 /* VSCFoundation.xcframework */; };
+		9794E1CB26AA0962001CF665 /* VirgilCrypto.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9794E1C326AA0962001CF665 /* VirgilCrypto.xcframework */; };
+		9794E1CD26AA0962001CF665 /* VSCPythia.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9794E1C426AA0962001CF665 /* VSCPythia.xcframework */; };
+		9794E1CF26AA0962001CF665 /* VirgilCryptoFoundation.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9794E1C526AA0962001CF665 /* VirgilCryptoFoundation.xcframework */; };
+		9794E1D126AA0962001CF665 /* VirgilCryptoPythia.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9794E1C626AA0962001CF665 /* VirgilCryptoPythia.xcframework */; };
+		9794E1D326AA0962001CF665 /* VirgilSDK.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9794E1C726AA0962001CF665 /* VirgilSDK.xcframework */; };
+		9794E1D526AA0962001CF665 /* VSCCommon.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9794E1C826AA0962001CF665 /* VSCCommon.xcframework */; };
+		9794E1D826AA09CA001CF665 /* VirgilCrypto.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9794E1C326AA0962001CF665 /* VirgilCrypto.xcframework */; };
+		9794E1DA26AA09CA001CF665 /* VirgilCryptoFoundation.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9794E1C526AA0962001CF665 /* VirgilCryptoFoundation.xcframework */; };
+		9794E1DC26AA09CA001CF665 /* VirgilCryptoPythia.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9794E1C626AA0962001CF665 /* VirgilCryptoPythia.xcframework */; };
+		9794E1DE26AA09CA001CF665 /* VirgilSDK.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9794E1C726AA0962001CF665 /* VirgilSDK.xcframework */; };
+		9794E1E026AA09CA001CF665 /* VSCCommon.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9794E1C826AA0962001CF665 /* VSCCommon.xcframework */; };
+		9794E1E226AA09CA001CF665 /* VSCFoundation.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9794E1C226AA0962001CF665 /* VSCFoundation.xcframework */; };
+		9794E1E426AA09CA001CF665 /* VSCPythia.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9794E1C426AA0962001CF665 /* VSCPythia.xcframework */; };
+		9794E1E726AA09F9001CF665 /* VirgilCrypto.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9794E1C326AA0962001CF665 /* VirgilCrypto.xcframework */; };
+		9794E1E926AA09F9001CF665 /* VirgilCryptoFoundation.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9794E1C526AA0962001CF665 /* VirgilCryptoFoundation.xcframework */; };
+		9794E1EB26AA09F9001CF665 /* VirgilCryptoPythia.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9794E1C626AA0962001CF665 /* VirgilCryptoPythia.xcframework */; };
+		9794E1ED26AA09F9001CF665 /* VirgilSDK.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9794E1C726AA0962001CF665 /* VirgilSDK.xcframework */; };
+		9794E1EF26AA09F9001CF665 /* VSCCommon.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9794E1C826AA0962001CF665 /* VSCCommon.xcframework */; };
+		9794E1F126AA09F9001CF665 /* VSCFoundation.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9794E1C226AA0962001CF665 /* VSCFoundation.xcframework */; };
+		9794E1F326AA09F9001CF665 /* VSCPythia.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9794E1C426AA0962001CF665 /* VSCPythia.xcframework */; };
+		9794E1F626AA0A1F001CF665 /* VirgilCrypto.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9794E1C326AA0962001CF665 /* VirgilCrypto.xcframework */; };
+		9794E1F826AA0A1F001CF665 /* VirgilCryptoFoundation.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9794E1C526AA0962001CF665 /* VirgilCryptoFoundation.xcframework */; };
+		9794E1FA26AA0A1F001CF665 /* VirgilCryptoPythia.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9794E1C626AA0962001CF665 /* VirgilCryptoPythia.xcframework */; };
+		9794E1FC26AA0A1F001CF665 /* VirgilSDK.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9794E1C726AA0962001CF665 /* VirgilSDK.xcframework */; };
+		9794E1FE26AA0A1F001CF665 /* VSCCommon.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9794E1C826AA0962001CF665 /* VSCCommon.xcframework */; };
+		9794E20026AA0A1F001CF665 /* VSCFoundation.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9794E1C226AA0962001CF665 /* VSCFoundation.xcframework */; };
+		9794E20226AA0A1F001CF665 /* VSCPythia.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9794E1C426AA0962001CF665 /* VSCPythia.xcframework */; };
+		9794E20526AA0AA3001CF665 /* VirgilCrypto.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9794E1C326AA0962001CF665 /* VirgilCrypto.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9794E20626AA0AA3001CF665 /* VirgilCryptoFoundation.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9794E1C526AA0962001CF665 /* VirgilCryptoFoundation.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9794E20726AA0AA3001CF665 /* VirgilCryptoPythia.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9794E1C626AA0962001CF665 /* VirgilCryptoPythia.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9794E20826AA0AA3001CF665 /* VirgilSDK.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9794E1C726AA0962001CF665 /* VirgilSDK.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9794E20926AA0AA3001CF665 /* VSCCommon.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9794E1C826AA0962001CF665 /* VSCCommon.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9794E20A26AA0AA3001CF665 /* VSCFoundation.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9794E1C226AA0962001CF665 /* VSCFoundation.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9794E20B26AA0AA3001CF665 /* VSCPythia.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9794E1C426AA0962001CF665 /* VSCPythia.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9794E20C26AA0C16001CF665 /* VirgilCrypto.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9794E1C326AA0962001CF665 /* VirgilCrypto.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9794E20D26AA0C16001CF665 /* VirgilCryptoFoundation.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9794E1C526AA0962001CF665 /* VirgilCryptoFoundation.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9794E20E26AA0C16001CF665 /* VirgilCryptoPythia.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9794E1C626AA0962001CF665 /* VirgilCryptoPythia.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9794E20F26AA0C16001CF665 /* VirgilSDK.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9794E1C726AA0962001CF665 /* VirgilSDK.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9794E21026AA0C16001CF665 /* VSCCommon.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9794E1C826AA0962001CF665 /* VSCCommon.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9794E21126AA0C16001CF665 /* VSCFoundation.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9794E1C226AA0962001CF665 /* VSCFoundation.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9794E21226AA0C16001CF665 /* VSCPythia.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9794E1C426AA0962001CF665 /* VSCPythia.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9794E21326AA0C28001CF665 /* VirgilCrypto.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9794E1C326AA0962001CF665 /* VirgilCrypto.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9794E21426AA0C28001CF665 /* VirgilCryptoFoundation.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9794E1C526AA0962001CF665 /* VirgilCryptoFoundation.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9794E21526AA0C28001CF665 /* VirgilCryptoPythia.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9794E1C626AA0962001CF665 /* VirgilCryptoPythia.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9794E21626AA0C28001CF665 /* VirgilSDK.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9794E1C726AA0962001CF665 /* VirgilSDK.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9794E21726AA0C28001CF665 /* VSCCommon.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9794E1C826AA0962001CF665 /* VSCCommon.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9794E21826AA0C28001CF665 /* VSCFoundation.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9794E1C226AA0962001CF665 /* VSCFoundation.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9794E21926AA0C28001CF665 /* VSCPythia.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9794E1C426AA0962001CF665 /* VSCPythia.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -182,13 +182,13 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				4264B6382240C8BE0096E6E4 /* VirgilCryptoFoundation.framework in CopyFiles */,
-				4264B63B2240C8BE0096E6E4 /* VirgilCryptoPythia.framework in CopyFiles */,
-				4264B63E2240C8BE0096E6E4 /* VSCCommon.framework in CopyFiles */,
-				4264B6412240C8BE0096E6E4 /* VSCFoundation.framework in CopyFiles */,
-				4264B6492240C8BE0096E6E4 /* VSCPythia.framework in CopyFiles */,
-				4264B64F2240C8BE0096E6E4 /* VirgilCrypto.framework in CopyFiles */,
-				4264B6512240C8BE0096E6E4 /* VirgilSDK.framework in CopyFiles */,
+				9794E21326AA0C28001CF665 /* VirgilCrypto.xcframework in CopyFiles */,
+				9794E21426AA0C28001CF665 /* VirgilCryptoFoundation.xcframework in CopyFiles */,
+				9794E21526AA0C28001CF665 /* VirgilCryptoPythia.xcframework in CopyFiles */,
+				9794E21626AA0C28001CF665 /* VirgilSDK.xcframework in CopyFiles */,
+				9794E21726AA0C28001CF665 /* VSCCommon.xcframework in CopyFiles */,
+				9794E21826AA0C28001CF665 /* VSCFoundation.xcframework in CopyFiles */,
+				9794E21926AA0C28001CF665 /* VSCPythia.xcframework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -198,13 +198,13 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				423F71AC223F98CB00E8CDA9 /* VirgilCryptoFoundation.framework in CopyFiles */,
-				423F71AF223F98CB00E8CDA9 /* VirgilCryptoPythia.framework in CopyFiles */,
-				423F71B2223F98CB00E8CDA9 /* VSCCommon.framework in CopyFiles */,
-				423F71B5223F98CB00E8CDA9 /* VSCFoundation.framework in CopyFiles */,
-				423F71BD223F98CB00E8CDA9 /* VSCPythia.framework in CopyFiles */,
-				424F67BC21EEA40200E70BAB /* VirgilCrypto.framework in CopyFiles */,
-				424F67BF21EEA40200E70BAB /* VirgilSDK.framework in CopyFiles */,
+				9794E20C26AA0C16001CF665 /* VirgilCrypto.xcframework in CopyFiles */,
+				9794E20D26AA0C16001CF665 /* VirgilCryptoFoundation.xcframework in CopyFiles */,
+				9794E20E26AA0C16001CF665 /* VirgilCryptoPythia.xcframework in CopyFiles */,
+				9794E20F26AA0C16001CF665 /* VirgilSDK.xcframework in CopyFiles */,
+				9794E21026AA0C16001CF665 /* VSCCommon.xcframework in CopyFiles */,
+				9794E21126AA0C16001CF665 /* VSCFoundation.xcframework in CopyFiles */,
+				9794E21226AA0C16001CF665 /* VSCPythia.xcframework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -214,13 +214,13 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				4264B5F92240C78C0096E6E4 /* VirgilCryptoFoundation.framework in CopyFiles */,
-				4264B5FC2240C78C0096E6E4 /* VirgilCryptoPythia.framework in CopyFiles */,
-				4264B6032240C78C0096E6E4 /* VSCCommon.framework in CopyFiles */,
-				4264B6042240C78C0096E6E4 /* VSCFoundation.framework in CopyFiles */,
-				4264B6052240C78C0096E6E4 /* VSCPythia.framework in CopyFiles */,
-				424F67C221EEA40E00E70BAB /* VirgilCrypto.framework in CopyFiles */,
-				424F67C521EEA40E00E70BAB /* VirgilSDK.framework in CopyFiles */,
+				9794E20526AA0AA3001CF665 /* VirgilCrypto.xcframework in CopyFiles */,
+				9794E20626AA0AA3001CF665 /* VirgilCryptoFoundation.xcframework in CopyFiles */,
+				9794E20726AA0AA3001CF665 /* VirgilCryptoPythia.xcframework in CopyFiles */,
+				9794E20826AA0AA3001CF665 /* VirgilSDK.xcframework in CopyFiles */,
+				9794E20926AA0AA3001CF665 /* VSCCommon.xcframework in CopyFiles */,
+				9794E20A26AA0AA3001CF665 /* VSCFoundation.xcframework in CopyFiles */,
+				9794E20B26AA0AA3001CF665 /* VSCPythia.xcframework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -231,35 +231,6 @@
 		420120F1207625F400632FD9 /* PythiaClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PythiaClient.swift; sourceTree = "<group>"; };
 		420120F5207625F400632FD9 /* PythiaClient+Queries.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PythiaClient+Queries.swift"; sourceTree = "<group>"; };
 		4201210A2077C1E800632FD9 /* PythiaCryptoProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PythiaCryptoProtocol.swift; sourceTree = "<group>"; };
-		423F7182223F981A00E8CDA9 /* VSCPythia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VSCPythia.framework; path = Carthage/Build/Mac/VSCPythia.framework; sourceTree = "<group>"; };
-		423F7183223F981A00E8CDA9 /* VSCCommon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VSCCommon.framework; path = Carthage/Build/Mac/VSCCommon.framework; sourceTree = "<group>"; };
-		423F7184223F981A00E8CDA9 /* VirgilCryptoFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VirgilCryptoFoundation.framework; path = Carthage/Build/Mac/VirgilCryptoFoundation.framework; sourceTree = "<group>"; };
-		423F7185223F981A00E8CDA9 /* VirgilCryptoPythia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VirgilCryptoPythia.framework; path = Carthage/Build/Mac/VirgilCryptoPythia.framework; sourceTree = "<group>"; };
-		423F7186223F981A00E8CDA9 /* VSCFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VSCFoundation.framework; path = Carthage/Build/Mac/VSCFoundation.framework; sourceTree = "<group>"; };
-		423F718C223F982A00E8CDA9 /* VSCPythia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VSCPythia.framework; path = Carthage/Build/tvOS/VSCPythia.framework; sourceTree = "<group>"; };
-		423F718D223F982A00E8CDA9 /* VSCFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VSCFoundation.framework; path = Carthage/Build/tvOS/VSCFoundation.framework; sourceTree = "<group>"; };
-		423F718E223F982A00E8CDA9 /* VSCCommon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VSCCommon.framework; path = Carthage/Build/tvOS/VSCCommon.framework; sourceTree = "<group>"; };
-		423F718F223F982A00E8CDA9 /* VirgilCryptoPythia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VirgilCryptoPythia.framework; path = Carthage/Build/tvOS/VirgilCryptoPythia.framework; sourceTree = "<group>"; };
-		423F7190223F982B00E8CDA9 /* VirgilCryptoFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VirgilCryptoFoundation.framework; path = Carthage/Build/tvOS/VirgilCryptoFoundation.framework; sourceTree = "<group>"; };
-		423F7196223F983B00E8CDA9 /* VirgilCryptoFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VirgilCryptoFoundation.framework; path = Carthage/Build/watchOS/VirgilCryptoFoundation.framework; sourceTree = "<group>"; };
-		423F7197223F983B00E8CDA9 /* VSCPythia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VSCPythia.framework; path = Carthage/Build/watchOS/VSCPythia.framework; sourceTree = "<group>"; };
-		423F7198223F983C00E8CDA9 /* VirgilCryptoRatchet.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VirgilCryptoRatchet.framework; path = Carthage/Build/watchOS/VirgilCryptoRatchet.framework; sourceTree = "<group>"; };
-		423F7199223F983C00E8CDA9 /* VSCFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VSCFoundation.framework; path = Carthage/Build/watchOS/VSCFoundation.framework; sourceTree = "<group>"; };
-		423F719A223F983C00E8CDA9 /* VSCCommon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VSCCommon.framework; path = Carthage/Build/watchOS/VSCCommon.framework; sourceTree = "<group>"; };
-		423F719B223F983C00E8CDA9 /* VirgilCryptoPythia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VirgilCryptoPythia.framework; path = Carthage/Build/watchOS/VirgilCryptoPythia.framework; sourceTree = "<group>"; };
-		423F71A2223F985000E8CDA9 /* VSCCommon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VSCCommon.framework; path = Carthage/Build/iOS/VSCCommon.framework; sourceTree = "<group>"; };
-		423F71A3223F985000E8CDA9 /* VSCPythia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VSCPythia.framework; path = Carthage/Build/iOS/VSCPythia.framework; sourceTree = "<group>"; };
-		423F71A4223F985000E8CDA9 /* VirgilCryptoPythia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VirgilCryptoPythia.framework; path = Carthage/Build/iOS/VirgilCryptoPythia.framework; sourceTree = "<group>"; };
-		423F71A5223F985000E8CDA9 /* VirgilCryptoFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VirgilCryptoFoundation.framework; path = Carthage/Build/iOS/VirgilCryptoFoundation.framework; sourceTree = "<group>"; };
-		423F71A6223F985000E8CDA9 /* VSCFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VSCFoundation.framework; path = Carthage/Build/iOS/VSCFoundation.framework; sourceTree = "<group>"; };
-		4249A09621EEA03D0076851C /* VirgilSDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VirgilSDK.framework; path = Carthage/Build/iOS/VirgilSDK.framework; sourceTree = "<group>"; };
-		4249A09821EEA03E0076851C /* VirgilCrypto.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VirgilCrypto.framework; path = Carthage/Build/iOS/VirgilCrypto.framework; sourceTree = "<group>"; };
-		4249A0A321EEA04E0076851C /* VirgilSDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VirgilSDK.framework; path = Carthage/Build/Mac/VirgilSDK.framework; sourceTree = "<group>"; };
-		4249A0A421EEA04E0076851C /* VirgilCrypto.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VirgilCrypto.framework; path = Carthage/Build/Mac/VirgilCrypto.framework; sourceTree = "<group>"; };
-		4249A0AB21EEA05C0076851C /* VirgilCrypto.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VirgilCrypto.framework; path = Carthage/Build/tvOS/VirgilCrypto.framework; sourceTree = "<group>"; };
-		4249A0AD21EEA05C0076851C /* VirgilSDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VirgilSDK.framework; path = Carthage/Build/tvOS/VirgilSDK.framework; sourceTree = "<group>"; };
-		4249A0B421EEA0700076851C /* VirgilSDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VirgilSDK.framework; path = Carthage/Build/watchOS/VirgilSDK.framework; sourceTree = "<group>"; };
-		4249A0B521EEA0700076851C /* VirgilCrypto.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VirgilCrypto.framework; path = Carthage/Build/watchOS/VirgilCrypto.framework; sourceTree = "<group>"; };
 		42792EB720A9A4B400C95A29 /* BrainKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrainKey.swift; sourceTree = "<group>"; };
 		42792EB920A9A52C00C95A29 /* BrainKey+Obj-C.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BrainKey+Obj-C.swift"; sourceTree = "<group>"; };
 		42792EBB20A9AAE200C95A29 /* BrainKeyContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrainKeyContext.swift; sourceTree = "<group>"; };
@@ -276,6 +247,13 @@
 		42DD298F20751B1A00C9C014 /* VirgilSDKPythia.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = VirgilSDKPythia.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		42DD299320751B1A00C9C014 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		42DD2A37207522D900C9C014 /* VirgilSDKPythia iOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "VirgilSDKPythia iOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		9794E1C226AA0962001CF665 /* VSCFoundation.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = VSCFoundation.xcframework; path = Carthage/Build/VSCFoundation.xcframework; sourceTree = "<group>"; };
+		9794E1C326AA0962001CF665 /* VirgilCrypto.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = VirgilCrypto.xcframework; path = Carthage/Build/VirgilCrypto.xcframework; sourceTree = "<group>"; };
+		9794E1C426AA0962001CF665 /* VSCPythia.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = VSCPythia.xcframework; path = Carthage/Build/VSCPythia.xcframework; sourceTree = "<group>"; };
+		9794E1C526AA0962001CF665 /* VirgilCryptoFoundation.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = VirgilCryptoFoundation.xcframework; path = Carthage/Build/VirgilCryptoFoundation.xcframework; sourceTree = "<group>"; };
+		9794E1C626AA0962001CF665 /* VirgilCryptoPythia.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = VirgilCryptoPythia.xcframework; path = Carthage/Build/VirgilCryptoPythia.xcframework; sourceTree = "<group>"; };
+		9794E1C726AA0962001CF665 /* VirgilSDK.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = VirgilSDK.xcframework; path = Carthage/Build/VirgilSDK.xcframework; sourceTree = "<group>"; };
+		9794E1C826AA0962001CF665 /* VSCCommon.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = VSCCommon.xcframework; path = Carthage/Build/VSCCommon.xcframework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -283,13 +261,13 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				423F7187223F981A00E8CDA9 /* VSCPythia.framework in Frameworks */,
-				423F7188223F981A00E8CDA9 /* VSCCommon.framework in Frameworks */,
-				423F7189223F981A00E8CDA9 /* VirgilCryptoFoundation.framework in Frameworks */,
-				423F718A223F981A00E8CDA9 /* VirgilCryptoPythia.framework in Frameworks */,
-				423F718B223F981A00E8CDA9 /* VSCFoundation.framework in Frameworks */,
-				4249A0A821EEA04E0076851C /* VirgilSDK.framework in Frameworks */,
-				4249A0A921EEA04E0076851C /* VirgilCrypto.framework in Frameworks */,
+				9794E1E426AA09CA001CF665 /* VSCPythia.xcframework in Frameworks */,
+				9794E1E026AA09CA001CF665 /* VSCCommon.xcframework in Frameworks */,
+				9794E1DA26AA09CA001CF665 /* VirgilCryptoFoundation.xcframework in Frameworks */,
+				9794E1E226AA09CA001CF665 /* VSCFoundation.xcframework in Frameworks */,
+				9794E1DC26AA09CA001CF665 /* VirgilCryptoPythia.xcframework in Frameworks */,
+				9794E1D826AA09CA001CF665 /* VirgilCrypto.xcframework in Frameworks */,
+				9794E1DE26AA09CA001CF665 /* VirgilSDK.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -305,13 +283,13 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				423F7191223F982B00E8CDA9 /* VSCPythia.framework in Frameworks */,
-				423F7192223F982B00E8CDA9 /* VSCFoundation.framework in Frameworks */,
-				423F7193223F982B00E8CDA9 /* VSCCommon.framework in Frameworks */,
-				423F7194223F982B00E8CDA9 /* VirgilCryptoPythia.framework in Frameworks */,
-				423F7195223F982B00E8CDA9 /* VirgilCryptoFoundation.framework in Frameworks */,
-				4249A0B021EEA05C0076851C /* VirgilCrypto.framework in Frameworks */,
-				4249A0B221EEA05C0076851C /* VirgilSDK.framework in Frameworks */,
+				9794E1F326AA09F9001CF665 /* VSCPythia.xcframework in Frameworks */,
+				9794E1EF26AA09F9001CF665 /* VSCCommon.xcframework in Frameworks */,
+				9794E1E926AA09F9001CF665 /* VirgilCryptoFoundation.xcframework in Frameworks */,
+				9794E1F126AA09F9001CF665 /* VSCFoundation.xcframework in Frameworks */,
+				9794E1EB26AA09F9001CF665 /* VirgilCryptoPythia.xcframework in Frameworks */,
+				9794E1E726AA09F9001CF665 /* VirgilCrypto.xcframework in Frameworks */,
+				9794E1ED26AA09F9001CF665 /* VirgilSDK.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -327,13 +305,13 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				423F719C223F983C00E8CDA9 /* VirgilCryptoFoundation.framework in Frameworks */,
-				423F719D223F983C00E8CDA9 /* VSCPythia.framework in Frameworks */,
-				423F719F223F983C00E8CDA9 /* VSCFoundation.framework in Frameworks */,
-				423F71A0223F983C00E8CDA9 /* VSCCommon.framework in Frameworks */,
-				423F71A1223F983C00E8CDA9 /* VirgilCryptoPythia.framework in Frameworks */,
-				4249A0B921EEA0700076851C /* VirgilSDK.framework in Frameworks */,
-				4249A0BA21EEA0700076851C /* VirgilCrypto.framework in Frameworks */,
+				9794E20226AA0A1F001CF665 /* VSCPythia.xcframework in Frameworks */,
+				9794E1FE26AA0A1F001CF665 /* VSCCommon.xcframework in Frameworks */,
+				9794E1F826AA0A1F001CF665 /* VirgilCryptoFoundation.xcframework in Frameworks */,
+				9794E20026AA0A1F001CF665 /* VSCFoundation.xcframework in Frameworks */,
+				9794E1FA26AA0A1F001CF665 /* VirgilCryptoPythia.xcframework in Frameworks */,
+				9794E1F626AA0A1F001CF665 /* VirgilCrypto.xcframework in Frameworks */,
+				9794E1FC26AA0A1F001CF665 /* VirgilSDK.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -341,13 +319,13 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				423F71A7223F985000E8CDA9 /* VSCCommon.framework in Frameworks */,
-				423F71A8223F985000E8CDA9 /* VSCPythia.framework in Frameworks */,
-				423F71A9223F985000E8CDA9 /* VirgilCryptoPythia.framework in Frameworks */,
-				423F71AA223F985000E8CDA9 /* VirgilCryptoFoundation.framework in Frameworks */,
-				423F71AB223F985000E8CDA9 /* VSCFoundation.framework in Frameworks */,
-				4249A09D21EEA03E0076851C /* VirgilCrypto.framework in Frameworks */,
-				4249A09B21EEA03E0076851C /* VirgilSDK.framework in Frameworks */,
+				9794E1CF26AA0962001CF665 /* VirgilCryptoFoundation.xcframework in Frameworks */,
+				9794E1C926AA0962001CF665 /* VSCFoundation.xcframework in Frameworks */,
+				9794E1CB26AA0962001CF665 /* VirgilCrypto.xcframework in Frameworks */,
+				9794E1CD26AA0962001CF665 /* VSCPythia.xcframework in Frameworks */,
+				9794E1D326AA0962001CF665 /* VirgilSDK.xcframework in Frameworks */,
+				9794E1D526AA0962001CF665 /* VSCCommon.xcframework in Frameworks */,
+				9794E1D126AA0962001CF665 /* VirgilCryptoPythia.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -456,35 +434,13 @@
 		42DD2A722075294900C9C014 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				423F7184223F981A00E8CDA9 /* VirgilCryptoFoundation.framework */,
-				423F7190223F982B00E8CDA9 /* VirgilCryptoFoundation.framework */,
-				423F71A5223F985000E8CDA9 /* VirgilCryptoFoundation.framework */,
-				423F7185223F981A00E8CDA9 /* VirgilCryptoPythia.framework */,
-				423F718F223F982A00E8CDA9 /* VirgilCryptoPythia.framework */,
-				423F71A4223F985000E8CDA9 /* VirgilCryptoPythia.framework */,
-				423F7183223F981A00E8CDA9 /* VSCCommon.framework */,
-				423F718E223F982A00E8CDA9 /* VSCCommon.framework */,
-				423F719A223F983C00E8CDA9 /* VSCCommon.framework */,
-				423F7186223F981A00E8CDA9 /* VSCFoundation.framework */,
-				423F718D223F982A00E8CDA9 /* VSCFoundation.framework */,
-				423F719B223F983C00E8CDA9 /* VirgilCryptoPythia.framework */,
-				423F71A2223F985000E8CDA9 /* VSCCommon.framework */,
-				423F71A6223F985000E8CDA9 /* VSCFoundation.framework */,
-				423F71A3223F985000E8CDA9 /* VSCPythia.framework */,
-				423F7198223F983C00E8CDA9 /* VirgilCryptoRatchet.framework */,
-				423F7199223F983C00E8CDA9 /* VSCFoundation.framework */,
-				423F7182223F981A00E8CDA9 /* VSCPythia.framework */,
-				423F718C223F982A00E8CDA9 /* VSCPythia.framework */,
-				423F7196223F983B00E8CDA9 /* VirgilCryptoFoundation.framework */,
-				423F7197223F983B00E8CDA9 /* VSCPythia.framework */,
-				4249A0B521EEA0700076851C /* VirgilCrypto.framework */,
-				4249A0B421EEA0700076851C /* VirgilSDK.framework */,
-				4249A0AB21EEA05C0076851C /* VirgilCrypto.framework */,
-				4249A0AD21EEA05C0076851C /* VirgilSDK.framework */,
-				4249A0A421EEA04E0076851C /* VirgilCrypto.framework */,
-				4249A0A321EEA04E0076851C /* VirgilSDK.framework */,
-				4249A09821EEA03E0076851C /* VirgilCrypto.framework */,
-				4249A09621EEA03D0076851C /* VirgilSDK.framework */,
+				9794E1C326AA0962001CF665 /* VirgilCrypto.xcframework */,
+				9794E1C526AA0962001CF665 /* VirgilCryptoFoundation.xcframework */,
+				9794E1C626AA0962001CF665 /* VirgilCryptoPythia.xcframework */,
+				9794E1C726AA0962001CF665 /* VirgilSDK.xcframework */,
+				9794E1C826AA0962001CF665 /* VSCCommon.xcframework */,
+				9794E1C226AA0962001CF665 /* VSCFoundation.xcframework */,
+				9794E1C426AA0962001CF665 /* VSCPythia.xcframework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -920,7 +876,6 @@
 		42A76B7220AED95200561EA2 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
@@ -931,12 +886,16 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/Mac",
+					"$(PROJECT_DIR)/Carthage/Build",
 				);
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = VirgilSDKPythia/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_BUNDLE_IDENTIFIER = com.virgilsecurity.VirgilSDKPythia;
 				PRODUCT_MODULE_NAME = VirgilSDKPythia;
@@ -952,7 +911,6 @@
 		42A76B7320AED95200561EA2 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
@@ -963,12 +921,16 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/Mac",
+					"$(PROJECT_DIR)/Carthage/Build",
 				);
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = VirgilSDKPythia/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_BUNDLE_IDENTIFIER = com.virgilsecurity.VirgilSDKPythia;
 				PRODUCT_MODULE_NAME = VirgilSDKPythia;
@@ -987,9 +949,13 @@
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Carthage/Build/Mac";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Carthage/Build";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_BUNDLE_IDENTIFIER = com.virgilsecurity.VirgilSDKPythiaTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -1006,9 +972,13 @@
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Carthage/Build/Mac";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Carthage/Build";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_BUNDLE_IDENTIFIER = com.virgilsecurity.VirgilSDKPythiaTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -1020,7 +990,6 @@
 		42A76BB020AED99B00561EA2 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
@@ -1030,11 +999,15 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/tvOS",
+					"$(PROJECT_DIR)/Carthage/Build",
 				);
 				INFOPLIST_FILE = VirgilSDKPythia/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.virgilsecurity.VirgilSDKPythia;
 				PRODUCT_MODULE_NAME = VirgilSDKPythia;
 				PRODUCT_NAME = VirgilSDKPythia;
@@ -1051,7 +1024,6 @@
 		42A76BB120AED99B00561EA2 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
@@ -1061,11 +1033,15 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/tvOS",
+					"$(PROJECT_DIR)/Carthage/Build",
 				);
 				INFOPLIST_FILE = VirgilSDKPythia/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.virgilsecurity.VirgilSDKPythia;
 				PRODUCT_MODULE_NAME = VirgilSDKPythia;
 				PRODUCT_NAME = VirgilSDKPythia;
@@ -1083,8 +1059,13 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Carthage/Build/tvOS";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Carthage/Build";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_BUNDLE_IDENTIFIER = com.virgilsecurity.VirgilSDKPythiaTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
@@ -1101,8 +1082,13 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Carthage/Build/tvOS";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Carthage/Build";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_BUNDLE_IDENTIFIER = com.virgilsecurity.VirgilSDKPythiaTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
@@ -1125,11 +1111,15 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+					"$(PROJECT_DIR)/Carthage/Build",
 				);
 				INFOPLIST_FILE = VirgilSDKPythia/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.virgilsecurity.VirgilSDKPythia;
 				PRODUCT_MODULE_NAME = VirgilSDKPythia;
 				PRODUCT_NAME = VirgilSDKPythia;
@@ -1155,11 +1145,15 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+					"$(PROJECT_DIR)/Carthage/Build",
 				);
 				INFOPLIST_FILE = VirgilSDKPythia/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.virgilsecurity.VirgilSDKPythia;
 				PRODUCT_MODULE_NAME = VirgilSDKPythia;
 				PRODUCT_NAME = VirgilSDKPythia;
@@ -1320,12 +1314,16 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build",
 				);
 				INFOPLIST_FILE = VirgilSDKPythia/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.virgilsecurity.VirgilSDKPythia;
 				PRODUCT_MODULE_NAME = VirgilSDKPythia;
 				PRODUCT_NAME = VirgilSDKPythia;
@@ -1349,12 +1347,16 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build",
 				);
 				INFOPLIST_FILE = VirgilSDKPythia/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.virgilsecurity.VirgilSDKPythia;
 				PRODUCT_MODULE_NAME = VirgilSDKPythia;
 				PRODUCT_NAME = VirgilSDKPythia;
@@ -1371,8 +1373,13 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Carthage/Build/iOS";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Carthage/Build";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.virgilsecurity.VirgilSDKPythia-iOS-Tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -1387,8 +1394,13 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Carthage/Build/iOS";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Carthage/Build";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.virgilsecurity.VirgilSDKPythia-iOS-Tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/VirgilSDKPythia/Info.plist
+++ b/VirgilSDKPythia/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.1</string>
+	<string>0.10.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
### Added
- Xcode 12.2+ support
- Apple Silicon support

### Project
- Use new format xcframeworks for dependencies
- Bumped up test targets macOS requirement to 10.15.0 (Xcode 12 warnings)
- Updated CI to latest Xcode & sdks

### Dependencies
- Updated `VirgilCryptoSDK` **7.2.1 --> 8.0.0**
- Updated `VirgilCryptoWrapper` **0.15.2 --> 0.16.0**

### Other
- Updated LICENCE & Copyright